### PR TITLE
Looser type checking for DOMDocumentFragment

### DIFF
--- a/test/unit/BindableTest.php
+++ b/test/unit/BindableTest.php
@@ -46,9 +46,6 @@ class BindableTest extends TestCase {
 		self::assertEquals($age,$spanChildren[1]->innerText);
 	}
 
-	/**
-	 * @expectedException \Gt\DomTemplate\InvalidBindProperty
-	 */
 	public function testBindOnUnknownProperty() {
 		$document = new HTMLDocument(Helper::HTML_BIND_UNKNOWN_PROPERTY);
 		$name = "Winston Smith";
@@ -57,6 +54,12 @@ class BindableTest extends TestCase {
 			"name" => $name,
 			"age" => $age,
 		]);
+
+		$test1 = $document->querySelector(".test1");
+		$test2 = $document->querySelector(".test2");
+
+		self::assertEquals($name, $test1->getAttribute("unknown"));
+		self::assertEquals($age, $test2->textContent);
 	}
 
 	public function testBindAttributeLookup() {

--- a/test/unit/Helper/Helper.php
+++ b/test/unit/Helper/Helper.php
@@ -161,8 +161,8 @@ HTML;
 			nisi, nostrum optio perferendis perspiciatis, rerum vitae voluptates.
 		</p>
 		<p class="bound-data-test">
-			My name is <span data-bind:unknown="name">Example</span> 
-			and I am <span data-bind:text="age">0</span> years old. 	
+			My name is <span class="test1" data-bind:unknown="name">Example</span> 
+			and I am <span class="test2" data-bind:text="age">0</span> years old. 	
 		</p>
 	</section>
 </main>


### PR DESCRIPTION
This change is required to allow binding data to custom components, as they are represented by a DocumentFragment, which is a Node, not an Element.