### PR TITLE
Bindable Mapper/Getter

### DIFF
--- a/src/BindDataGetter.php
+++ b/src/BindDataGetter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Gt\DomTemplate;
+
+/**
+ * This interface does not define any functions, but is used to indicate that
+ * the implementing class should expose "get*" functions for the key-value data
+ * it represents.
+ *
+ * For example: class Person implements BindDataGetter {
+ *      // This function will be called for the "name" key when bound.
+ * 	public function getName():string {
+ * 		return $this->forename . " " . $this->surname;
+ * 	}
+ * }
+ */
+interface BindDataGetter {}

--- a/src/BindDataMapper.php
+++ b/src/BindDataMapper.php
@@ -1,0 +1,15 @@
+<?php
+namespace Gt\DomTemplate;
+
+interface BindDataMapper {
+	/**
+	 * @return array An associative array that describes the key-values
+	 * required to bind to the DomTemplate document.
+	 *
+	 * Example: [
+	 * 	"fullName" => $this->forename . " " . $this->surname,
+	 * 	"age" => date("Y") - $this->dob->format("Y"),
+	 * ]
+	 */
+	public function bindDataMap():array;
+}

--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -14,7 +14,7 @@ trait Bindable {
 	/**
 	 * Alias of bindKeyValue.
 	 */
-	public function bind(?string $key, string $value):void {
+	public function bind(?string $key, ?string $value):void {
 		$this->bindKeyValue($key, $value);
 	}
 
@@ -26,7 +26,7 @@ trait Bindable {
 	 */
 	public function bindKeyValue(
 		?string $key,
-		string $value
+		?string $value
 	):void {
 		$this->injectBoundProperty($key, $value);
 		$this->injectAttributePlaceholder($key, $value);
@@ -37,7 +37,7 @@ trait Bindable {
 	 * attribute vale. For example, <p data-bind:text>Your text here</p>
 	 * does not have an addressable attribute value for data-bind:text.
 	 */
-	public function bindValue(string $value):void {
+	public function bindValue(?string $value):void {
 		$this->bindKeyValue(null, $value);
 // Note, it's impossible to inject attribute placeholders without a key.
 	}

--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -54,7 +54,33 @@ trait Bindable {
 	public function bindData(
 		$kvp
 	):void {
-		foreach($kvp as $key => $value) {
+		$iterable = $kvp;
+
+		if(!is_iterable($kvp)) {
+			if($kvp instanceof BindDataMapper) {
+				$iterable = $kvp->bindDataMap();
+			}
+			elseif($kvp instanceof BindDataGetter) {
+				$iterable = [];
+
+				foreach(get_class_methods($kvp) as $method) {
+					if(strpos($method, "get") !== 0) {
+						continue;
+					}
+
+					$key = lcfirst(substr($method, 3));
+					$value = $kvp->$method();
+					$iterable[$key] = $value;
+				}
+			}
+			else {
+				throw new UnbindableObjectException(
+					get_class($kvp)
+				);
+			}
+		}
+
+		foreach($iterable as $key => $value) {
 			$this->bindKeyValue($key, $value);
 		}
 	}

--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -28,6 +28,10 @@ trait Bindable {
 		?string $key,
 		?string $value
 	):void {
+		if(is_null($value)) {
+			$value = "";
+		}
+
 		$this->injectBoundProperty($key, $value);
 		$this->injectAttributePlaceholder($key, $value);
 	}
@@ -157,7 +161,7 @@ trait Bindable {
 	 */
 	protected function injectBoundProperty(
 		?string $key,
-		string $value
+		?string $value
 	):void {
 		$children = $this->getChildrenWithBindAttribute();
 

--- a/src/UnbindableObjectException.php
+++ b/src/UnbindableObjectException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Gt\DomTemplate;
+
+class UnbindableObjectException extends DomTemplateException {}


### PR DESCRIPTION
Two new interfaces are supplied in this PR: BindDataGetter and BindDataMapper.

If you want to use an object to bind with `bindData` or an array of your objects with `bindList`, you can implement one of the interfaces to dictate how the data will be bound.

Mapper will return a key-value-pair associative array, and Getter will allow all get* functions to be used for the bind matching.