### PR TITLE
Allow bindable objects

### DIFF
--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -14,7 +14,7 @@ trait Bindable {
 	/**
 	 * Alias of bindKeyValue.
 	 */
-	public function bind(?string $key, ?string $value):void {
+	public function bind(?string $key, $value):void {
 		$this->bindKeyValue($key, $value);
 	}
 
@@ -26,7 +26,7 @@ trait Bindable {
 	 */
 	public function bindKeyValue(
 		?string $key,
-		?string $value
+		$value
 	):void {
 		if(is_null($value)) {
 			$value = "";
@@ -219,7 +219,7 @@ trait Bindable {
 	 */
 	protected function injectBoundProperty(
 		?string $key,
-		?string $value
+		$value
 	):void {
 		foreach($this->getChildrenWithBindAttribute() as $child) {
 			foreach($child->attributes as $attr) {
@@ -304,7 +304,7 @@ trait Bindable {
 
 	protected function injectAttributePlaceholder(
 		?string $key,
-		string $value
+		$value
 	):void {
 		/** @var BaseElement $element */
 		$element = $this;

--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -40,8 +40,10 @@ trait Bindable {
 	 * Bind a single value to a data-bind element that has no matching
 	 * attribute vale. For example, <p data-bind:text>Your text here</p>
 	 * does not have an addressable attribute value for data-bind:text.
+	 *
+	 * @param mixed $value
 	 */
-	public function bindValue(?string $value):void {
+	public function bindValue($value):void {
 		$this->bindKeyValue(null, $value);
 // Note, it's impossible to inject attribute placeholders without a key.
 	}

--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -107,7 +107,7 @@ trait Bindable {
 	public function bindList(
 		iterable $kvpList,
 		string $templateName = null
-	):void {
+	):int {
 		/** @var BaseElement $element */
 		$element = $this;
 		if($element instanceof HTMLDocument) {
@@ -130,7 +130,9 @@ trait Bindable {
 			$templateElement = $document->getNamedTemplate($templateName);
 		}
 
+		$i = 0;
 		foreach($kvpList as $data) {
+			$i++;
 			$t = $templateElement->cloneNode(true);
 
 			if(!$templateParent) {
@@ -141,9 +143,16 @@ trait Bindable {
 			$fragment->appendChild($t);
 		}
 
+		global $test;
+		if($test) {
+			var_dump($templateParent->getNodePath());die();
+		}
+
 		if(!is_null($templateParent)) {
 			$templateParent->appendChild($fragment);
 		}
+
+		return $i;
 	}
 
 	/**

--- a/test/unit/BindableTest.php
+++ b/test/unit/BindableTest.php
@@ -184,7 +184,7 @@ class BindableTest extends TestCase {
 	}
 
 	public function testInjectAttributePlaceholderNoDataBindParameters() {
-		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS);
+		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS_NO_BIND);
 		$userId = 101;
 		$username = "thoughtpolice";
 		$link = $document->querySelector("a");
@@ -202,7 +202,7 @@ class BindableTest extends TestCase {
 	}
 
 	public function testBindParametersPlaceholder() {
-		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS);
+		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS_NO_BIND);
 		$userId = 101;
 		$username = "thoughtpolice";
 		$link = $document->querySelector("a");
@@ -219,7 +219,7 @@ class BindableTest extends TestCase {
 	}
 
 	public function testBindParametersMultiple() {
-		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS);
+		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS_NO_BIND);
 		$userId = 101;
 		$userType = "thinkpol";
 		$h1 = $document->querySelector("h1");
@@ -231,7 +231,7 @@ class BindableTest extends TestCase {
 	}
 
 	public function testBindParametersMultipleInHref() {
-		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS);
+		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS_NO_BIND);
 		$userId = 101;
 		$userType = "thinkpol";
 		$footer = $document->querySelector("footer");
@@ -462,5 +462,24 @@ class BindableTest extends TestCase {
 		$spans = $document->querySelectorAll(".bound-data-test span");
 		self::assertEquals($dataObj->name, $spans[0]->innerText);
 		self::assertEquals($dataObj->age, $spans[1]->innerText);
+	}
+
+	public function testBindObjectValueParameter() {
+		$dataObj = new StdClass();
+		$dataObj->userId = 123;
+		$dataObj->username = "Testname";
+
+		$document = new HTMLDocument(Helper::HTML_ATTRIBUTE_PLACEHOLDERS);
+		$document->bindData($dataObj);
+
+		$img = $document->querySelector("img");
+		self::assertStringContainsString(
+			"{$dataObj->userId}.jpg",
+			$img->src
+		);
+		self::assertEquals(
+			"{$dataObj->username}'s profile picture",
+			$img->alt
+		);
 	}
 }

--- a/test/unit/BindableTest.php
+++ b/test/unit/BindableTest.php
@@ -7,6 +7,7 @@ use Gt\DomTemplate\HTMLDocument;
 use Gt\DomTemplate\NamelessTemplateSpecificityException;
 use Gt\DomTemplate\Test\Helper\Helper;
 use NumberFormatter;
+use stdClass;
 
 class BindableTest extends TestCase {
 	public function testBindMethodAvailable() {
@@ -448,5 +449,18 @@ class BindableTest extends TestCase {
 			self::assertEquals($expectedText, $text);
 			self::assertEquals($i, $value);
 		}
+	}
+
+	public function testBindObjectValue() {
+		$dataObj = new StdClass();
+		$dataObj->name = "Test name";
+		$dataObj->age = 123;
+
+		$document = new HTMLDocument(Helper::HTML_NO_TEMPLATES);
+		$document->bindData($dataObj);
+
+		$spans = $document->querySelectorAll(".bound-data-test span");
+		self::assertEquals($dataObj->name, $spans[0]->innerText);
+		self::assertEquals($dataObj->age, $spans[1]->innerText);
 	}
 }

--- a/test/unit/Helper/Helper.php
+++ b/test/unit/Helper/Helper.php
@@ -419,7 +419,7 @@ HTML;
 HTML;
 
 
-	const HTML_ATTRIBUTE_PLACEHOLDERS = <<<HTML
+	const HTML_ATTRIBUTE_PLACEHOLDERS_NO_BIND = <<<HTML
 <!doctype html>
 <meta charset="utf-8" />
 <title>This document has some elements with attribute placeholders</title>
@@ -434,6 +434,24 @@ HTML;
 </main>
 <footer>
 	<a href="/user.php?id={userId}&type={userType}">Another link in the footer</a>
+</footer>
+HTML;
+
+	const HTML_ATTRIBUTE_PLACEHOLDERS = <<<HTML
+<!doctype html>
+<meta charset="utf-8" />
+<title>This document has some elements with attribute placeholders</title>
+<main>
+	<h1 id="heading-{userType}-{userId}" data-bind-parameters>This is a test!</h1>
+	<p><a id="userType-{userType}" href="/user/{userId}" data-bind-parameters>View your account</a></p>
+	
+	<p>You are logged in.</p>
+	<p>This is your profile picture:</p>
+	
+	<img src="/img/profile/{userId}.jpg" alt="{username}'s profile picture" data-bind-parameters />
+</main>
+<footer>
+	<a href="/user.php?id={userId}&type={userType}" data-bind-parameters>Another link in the footer</a>
 </footer>
 HTML;
 


### PR DESCRIPTION
This PR removes bug #76 and allows any object to be used as a bindable value. This means a data object can be used, or any object with public properties.