### PR TITLE
PHP 7.4 compatibility (preventing array access to null)

### DIFF
--- a/src/Bindable.php
+++ b/src/Bindable.php
@@ -271,6 +271,10 @@ trait Bindable {
 	):?string {
 		$keyToSet = $attr->value ?: null;
 
+		if(is_null($keyToSet)) {
+			return null;
+		}
+
 		if($keyToSet[0] === "@") {
 			$lookupAttribute = substr($keyToSet, 1);
 			$keyToSet = $attr->ownerElement->getAttribute(


### PR DESCRIPTION
The getKeyToSet function initialises `$keyToSet` to null if there is a falsey value on the provided attribute.

Null can no longer be accessed as an array (and rightly so!), so this fix prevents a fatal error in PHP 7.4.