### PR TITLE
Unbound lists are made empty

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "c07f070d57106e34d9309d88fa29f50d",
@@ -239,16 +239,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/579bb7356d91f9456ccd505f24ca8b667966a0a7",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -283,7 +283,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-12-15T19:12:40+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -540,24 +540,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.1",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5 || ^3.2",
@@ -599,7 +599,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-22T21:05:45+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/DocumentFragment.php
+++ b/src/DocumentFragment.php
@@ -16,23 +16,23 @@ class DocumentFragment extends BaseDocumentFragment {
 	/** @var BaseElement */
 	public $templateParentNode;
 	/** @var BaseElement */
-	public $templateNextSibling;
+	public $templateNextElementSibling;
 	/** @var BaseElement */
-	public $templatePreviousSibling;
+	public $templatePreviousElementSibling;
 
 	/**
 	 * @param BaseNode $parentNode
-	 * @param BaseNode $nextSibling
-	 * @param BaseNode $previousSibling
+	 * @param BaseNode $nextElementSibling
+	 * @param BaseNode $previousElementSibling
 	 */
 	public function setTemplateProperties(
 		$parentNode = null,
-		$nextSibling = null,
-		$previousSibling = null
+		$nextElementSibling = null,
+		$previousElementSibling = null
 	):void {
 		$this->templateParentNode = $parentNode;
-		$this->templateNextSibling = $nextSibling;
-		$this->templatePreviousSibling = $previousSibling;
+		$this->templateNextElementSibling = $nextElementSibling;
+		$this->templatePreviousElementSibling = $previousElementSibling;
 	}
 
 	/**
@@ -43,7 +43,7 @@ class DocumentFragment extends BaseDocumentFragment {
 
 		if(is_null($insertInto)) {
 			$insertInto = $this->templateParentNode;
-			$insertBefore = $this->templateNextSibling;
+			$insertBefore = $this->templateNextElementSibling;
 		}
 		if(is_null($insertInto)) {
 			throw new TemplateHasNoParentException();
@@ -58,17 +58,5 @@ class DocumentFragment extends BaseDocumentFragment {
 		);
 
 		return $inserted;
-	}
-
-	public function prop_get_templateNextSibling() {
-		return $this->templateNextSibling;
-	}
-
-	public function prop_get_templatePreviousSibling() {
-		return $this->templatePreviousSibling;
-	}
-
-	public function prop_get_templateParentNode() {
-		return $this->templateParentNode;
 	}
 }

--- a/src/HTMLDocument.php
+++ b/src/HTMLDocument.php
@@ -61,8 +61,8 @@ class HTMLDocument extends BaseHTMLDocument {
 			$clone = $fragment->cloneNode(true);
 			$clone->setTemplateProperties(
 				$fragment->templateParentNode,
-				$fragment->templateNextSibling,
-				$fragment->templatePreviousSibling
+				$fragment->templateNextElementSibling,
+				$fragment->templatePreviousElementSibling
 			);
 
 			return $clone;
@@ -105,8 +105,8 @@ class HTMLDocument extends BaseHTMLDocument {
 		$clone = $fragment->cloneNode(true);
 		$clone->setTemplateProperties(
 			$fragment->templateParentNode,
-			$fragment->templateNextSibling,
-			$fragment->templatePreviousSibling
+			$fragment->templateNextElementSibling,
+			$fragment->templatePreviousElementSibling
 		);
 
 		return $clone;
@@ -120,7 +120,6 @@ class HTMLDocument extends BaseHTMLDocument {
 // Unnamed templates can't have sibling elements of the same path, otherwise
 // they would need to be named. Remove any index from the path.
 		$path = preg_replace("/\[\d+\]/", "", $path);
-		$matches = [];
 		$pathToReturn = null;
 
 		foreach($this->templateFragmentMap as $name => $t) {
@@ -149,6 +148,7 @@ class HTMLDocument extends BaseHTMLDocument {
 			return null;
 		}
 
+		/** @var Element[] $matchingElements */
 		$matchingElements =  $this->xPath($pathToReturn);
 		return $matchingElements[count($matchingElements) - 1];
 	}

--- a/src/TemplateParent.php
+++ b/src/TemplateParent.php
@@ -24,8 +24,8 @@ trait TemplateParent {
 			$name = $this->getTemplateNameFromElement($templateElement);
 
 			$parentNode = $templateElement->parentNode;
-			$nextSibling = $templateElement->nextSibling;
-			$previousSibling = $templateElement->previousSibling;
+			$nextElementSibling = $templateElement->nextElementSibling;
+			$previousElementSibling = $templateElement->previousElementSibling;
 			$templateNodePath = $templateElement->getNodePath();
 
 			$nestedTemplateElementList = $templateElement->querySelectorAll(
@@ -45,8 +45,8 @@ trait TemplateParent {
 			);
 			$fragment->setTemplateProperties(
 				$parentNode,
-				$nextSibling,
-				$previousSibling
+				$nextElementSibling,
+				$previousElementSibling
 			);
 			$fragment->expandComponents();
 
@@ -65,6 +65,10 @@ trait TemplateParent {
 
 			if($templateElement->parentNode === $parentNode) {
 				$parentNode->removeChild($templateElement);
+			}
+
+			if(count($parentNode->children) === 0) {
+				$parentNode->innerHTML = "";
 			}
 
 			if($name[0] !== "/") {
@@ -88,11 +92,17 @@ trait TemplateParent {
 		string $templateDirectory = null,
 		bool $addTemplatePrefix = true
 	):DocumentFragment {
+		/** @var Element $element */
+		$element = $this;
+
 		/** @var HTMLDocument $rootDocument */
-		$rootDocument = $this->getRootDocument();
+		$rootDocument = $element->getRootDocument();
 
 		if(is_null($name)) {
-			$docTemplate = $rootDocument->getUnnamedTemplate($this, false);
+			$docTemplate = $rootDocument->getUnnamedTemplate(
+				$element,
+				false
+			);
 		}
 		else {
 			$docTemplate = $rootDocument->getNamedTemplate($name);
@@ -102,7 +112,7 @@ trait TemplateParent {
 		}
 
 		if(is_null($templateDirectory)) {
-			$templateDirectory = $this->componentDirectory;
+			$templateDirectory = $element->componentDirectory;
 		}
 
 		if(is_dir($templateDirectory)) {
@@ -115,7 +125,7 @@ trait TemplateParent {
 				$fileName = strtok($fileName, ".");
 
 				if($name === $fileName) {
-					$component = $this->loadComponent(
+					$component = $element->loadComponent(
 						$name,
 						dirname($fileInfo->getRealPath())
 					);

--- a/test/unit/HTMLDocumentTest.php
+++ b/test/unit/HTMLDocumentTest.php
@@ -4,7 +4,6 @@ namespace Gt\DomTemplate\Test;
 use Gt\DomTemplate\DocumentFragment;
 use Gt\DomTemplate\Element;
 use Gt\DomTemplate\HTMLDocument;
-use Gt\DomTemplate\Test\Helper\Helper;
 
 class HTMLDocumentTest extends TestCase {
 	public function testOverriddenClasses() {
@@ -18,12 +17,5 @@ class HTMLDocumentTest extends TestCase {
 		$document = new HTMLDocument("<!doctype html><h1 id='test'>Test</h1>");
 		$element = $document->getElementById("test");
 		self::assertInstanceOf(Element::class, $element);
-	}
-
-	public function testExtractTemplatesSetsParentInnerHTMLToEmpty() {
-		$document = new HTMLDocument(Helper::HTML_TODO_LIST);
-		$document->extractTemplates();
-		$todoListElement = $document->getElementById("todo-list");
-		self::assertSame("", $todoListElement->innerHTML);
 	}
 }

--- a/test/unit/HTMLDocumentTest.php
+++ b/test/unit/HTMLDocumentTest.php
@@ -4,6 +4,7 @@ namespace Gt\DomTemplate\Test;
 use Gt\DomTemplate\DocumentFragment;
 use Gt\DomTemplate\Element;
 use Gt\DomTemplate\HTMLDocument;
+use Gt\DomTemplate\Test\Helper\Helper;
 
 class HTMLDocumentTest extends TestCase {
 	public function testOverriddenClasses() {
@@ -17,5 +18,12 @@ class HTMLDocumentTest extends TestCase {
 		$document = new HTMLDocument("<!doctype html><h1 id='test'>Test</h1>");
 		$element = $document->getElementById("test");
 		self::assertInstanceOf(Element::class, $element);
+	}
+
+	public function testExtractTemplatesSetsParentInnerHTMLToEmpty() {
+		$document = new HTMLDocument(Helper::HTML_TODO_LIST);
+		$document->extractTemplates();
+		$todoListElement = $document->getElementById("todo-list");
+		self::assertSame("", $todoListElement->innerHTML);
 	}
 }

--- a/test/unit/Helper/Helper.php
+++ b/test/unit/Helper/Helper.php
@@ -356,6 +356,26 @@ HTML;
 </main>
 HTML;
 
+	const HTML_NESTED_LIST = <<<HTML
+<!doctype html>
+<meta charset="utf-8" />
+<title>Nested list</title>
+<main>
+	<ul>
+		<li data-template>
+			<h1 data-bind:text>Outer title goes here</h1>
+			
+			<ol>
+				<li data-template>
+					<h2 data-bind:text>Inner title goes here</h2>				
+				</li>			
+			</ol>		
+		</li>
+	</ul>
+</main>
+HTML;
+
+
 	const HTML_PARENT_HAS_DATA_BIND_ATTR = <<<HTML
 <!doctype html>
 <meta charset="utf-8" />

--- a/test/unit/Helper/Helper.php
+++ b/test/unit/Helper/Helper.php
@@ -362,11 +362,11 @@ HTML;
 <title>Nested list</title>
 <main>
 	<ul>
-		<li data-template>
-			<h1 data-bind:text>Outer title goes here</h1>
+		<li data-template class="outer">
+			<h1 data-bind:text>0:0</h1>
 			
 			<ol>
-				<li data-template>
+				<li data-template class="inner">
 					<h2 data-bind:text>Inner title goes here</h2>				
 				</li>			
 			</ol>		

--- a/test/unit/TemplateParentTest.php
+++ b/test/unit/TemplateParentTest.php
@@ -459,17 +459,32 @@ class TemplateParentTest extends TestCase {
 		$document->extractTemplates();
 		$outerListElement = $document->querySelector("ul");
 		self::assertEmpty($outerListElement->innerHTML);
-// An example of binding some real data to this example:
-//		$document->bindNestedList([
-//			"Outer 1" => (object)[
-//				"Inner 1:1" => ["name" => uniqid("Inner 1:1 ")],
-//				"Inner 1:2" => ["name" => uniqid("Inner 1:2 ")],
-//				"Inner 1:3" => ["name" => uniqid("Inner 1:3 ")],
-//			],
-//			"Outer 2" => (object)[
-//				"Inner 2:1" => ["name" => uniqid("Inner 2:1 ")],
-//				"Inner 2:2" => ["name" => uniqid("Inner 2:2 ")],
-//			],
-//		]);
+	}
+
+	public function testExtractTemplatesSetsNestedParentInnerHTMLPartiallyToEmpty() {
+		$document = new HTMLDocument(Helper::HTML_NESTED_LIST);
+		$document->extractTemplates();
+		$outerListElement = $document->querySelector("ul");
+		$document->bindNestedList([
+			"Outer 1" => [
+				"1:1" => [],
+				"1:2" => [],
+				"1:3" => [],
+			],
+			"Outer 2" => [],
+			"Outer 3" => [
+				"3:1" => [
+					"Example" => (object)[
+						"name" => "Here I am!"
+					]
+				],
+				"3:2" => [],
+			],
+		]);
+
+		self::assertNotEmpty($outerListElement->innerHTML);
+		self::assertNotEmpty($outerListElement->querySelectorAll("ol")[0]->innerHTML);
+		self::assertNotEmpty($outerListElement->querySelectorAll("ol")[2]->innerHTML);
+		self::assertEmpty($outerListElement->querySelectorAll("ol")[1]->innerHTML);
 	}
 }

--- a/test/unit/TemplateParentTest.php
+++ b/test/unit/TemplateParentTest.php
@@ -446,4 +446,11 @@ class TemplateParentTest extends TestCase {
 
 		self::assertCount(3, $componentElement->children);
 	}
+
+	public function testExtractTemplatesSetsParentInnerHTMLToEmpty() {
+		$document = new HTMLDocument(Helper::HTML_TODO_LIST);
+		$document->extractTemplates();
+		$todoListElement = $document->getElementById("todo-list");
+		self::assertSame("", $todoListElement->innerHTML);
+	}
 }

--- a/test/unit/TemplateParentTest.php
+++ b/test/unit/TemplateParentTest.php
@@ -451,6 +451,25 @@ class TemplateParentTest extends TestCase {
 		$document = new HTMLDocument(Helper::HTML_TODO_LIST);
 		$document->extractTemplates();
 		$todoListElement = $document->getElementById("todo-list");
-		self::assertSame("", $todoListElement->innerHTML);
+		self::assertEmpty($todoListElement->innerHTML);
+	}
+
+	public function testExtractTemplatesSetsNestedParentInnerHTMLToEmpty() {
+		$document = new HTMLDocument(Helper::HTML_NESTED_LIST);
+		$document->extractTemplates();
+		$outerListElement = $document->querySelector("ul");
+		self::assertEmpty($outerListElement->innerHTML);
+// An example of binding some real data to this example:
+//		$document->bindNestedList([
+//			"Outer 1" => (object)[
+//				"Inner 1:1" => ["name" => uniqid("Inner 1:1 ")],
+//				"Inner 1:2" => ["name" => uniqid("Inner 1:2 ")],
+//				"Inner 1:3" => ["name" => uniqid("Inner 1:3 ")],
+//			],
+//			"Outer 2" => (object)[
+//				"Inner 2:1" => ["name" => uniqid("Inner 2:1 ")],
+//				"Inner 2:2" => ["name" => uniqid("Inner 2:2 ")],
+//			],
+//		]);
 	}
 }


### PR DESCRIPTION
Since #124, binding empty lists ensures the innerHTML of a parent is empty, but this PR ensures that a list that is never bound to will also be empty, under the same circumstances.