### PR TITLE
feature: allow binding directly to `data-element`

### DIFF
--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -159,12 +159,12 @@ class DocumentBinder extends Binder {
 	}
 
 	public function cleanupDocument():void {
+		/** @var Attr[] $xpathResult */
 		$xpathResult = $this->document->evaluate(
 			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')] | //*/@*[starts-with(name(), 'data-element')]"
 		);
 
 		$elementsToRemove = [];
-		/** @var Attr $item */
 		foreach($xpathResult as $item) {
 			$ownerElement = $item->ownerElement;
 			if($ownerElement->hasAttribute("data-element")) {

--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -159,7 +159,7 @@ class DocumentBinder extends Binder {
 	}
 
 	public function cleanupDocument():void {
-		/** @var Attr[] $xpathResult */
+		/** @var \Gt\Dom\XPathResult<Attr> $xpathResult */
 		$xpathResult = $this->document->evaluate(
 			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')] | //*/@*[starts-with(name(), 'data-element')]"
 		);

--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -158,10 +158,10 @@ class DocumentBinder extends Binder {
 		);
 	}
 
-	// @phpstan-ignore varTag.nativeType
 	public function cleanupDocument():void {
 		/**
 		 * @var Attr[] $xpathResult
+		 * @phpstan-ignore varTag.nativeType
 		 */
 		$xpathResult = $this->document->evaluate(
 			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')] | //*/@*[starts-with(name(), 'data-element')]"

--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -159,7 +159,10 @@ class DocumentBinder extends Binder {
 	}
 
 	public function cleanupDocument():void {
-		/** @var \Gt\Dom\XPathResult<Attr> $xpathResult */
+		/**
+		 * @phpstan-ignore-next-line
+		 * @var Attr[] $xpathResult
+		 */
 		$xpathResult = $this->document->evaluate(
 			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')] | //*/@*[starts-with(name(), 'data-element')]"
 		);

--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -158,9 +158,9 @@ class DocumentBinder extends Binder {
 		);
 	}
 
+	// @phpstan-ignore varTag.nativeType
 	public function cleanupDocument():void {
 		/**
-		 * @phpstan-ignore-next-line
 		 * @var Attr[] $xpathResult
 		 */
 		$xpathResult = $this->document->evaluate(

--- a/src/DocumentBinder.php
+++ b/src/DocumentBinder.php
@@ -160,22 +160,28 @@ class DocumentBinder extends Binder {
 
 	public function cleanupDocument():void {
 		$xpathResult = $this->document->evaluate(
-			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')]"
+			"//*/@*[starts-with(name(), 'data-bind')] | //*/@*[starts-with(name(), 'data-list')] | //*/@*[starts-with(name(), 'data-template')] | //*/@*[starts-with(name(), 'data-table-key')] | //*/@*[starts-with(name(), 'data-element')]"
 		);
 
 		$elementsToRemove = [];
 		/** @var Attr $item */
 		foreach($xpathResult as $item) {
-			if($item->ownerElement->hasAttribute("data-element")) {
-				array_push($elementsToRemove, $item->ownerElement);
+			$ownerElement = $item->ownerElement;
+			if($ownerElement->hasAttribute("data-element")) {
+				if(!$ownerElement->hasAttribute("data-bound")) {
+					array_push($elementsToRemove, $ownerElement);
+				}
 				continue;
 			}
 
-			$item->ownerElement->removeAttribute($item->name);
+			$ownerElement->removeAttribute($item->name);
 		}
 
 		foreach($this->document->querySelectorAll("[data-element]") as $dataElement) {
 			$dataElement->removeAttribute("data-element");
+		}
+		foreach($this->document->querySelectorAll("[data-bound]") as $dataBound) {
+			$dataBound->removeAttribute("data-bound");
 		}
 
 		foreach($elementsToRemove as $element) {

--- a/src/HTMLAttributeBinder.php
+++ b/src/HTMLAttributeBinder.php
@@ -43,7 +43,7 @@ class HTMLAttributeBinder {
 
 			if($attrName === "data-element") {
 				if($attr->value === $key && $value) {
-					$element->setAttribute("data-bound", true);
+					$element->setAttribute("data-bound", "");
 				}
 			}
 
@@ -87,7 +87,7 @@ class HTMLAttributeBinder {
 				$value,
 				$modifier
 			);
-			$element->setAttribute("data-bound", true);
+			$element->setAttribute("data-bound", "");
 
 			if(!$attr->ownerElement->hasAttribute("data-rebind")) {
 				array_push($attributesToRemove, $attrName);

--- a/src/HTMLAttributeBinder.php
+++ b/src/HTMLAttributeBinder.php
@@ -41,6 +41,12 @@ class HTMLAttributeBinder {
 		foreach($element->attributes as $attrName => $attr) {
 			$attrValue = $attr->value;
 
+			if($attrName === "data-element") {
+				if($attr->value === $key && $value) {
+					$element->setAttribute("data-bound", true);
+				}
+			}
+
 			if(!str_starts_with($attrName, "data-bind")) {
 				continue;
 			}
@@ -81,6 +87,7 @@ class HTMLAttributeBinder {
 				$value,
 				$modifier
 			);
+			$element->setAttribute("data-bound", true);
 
 			if(!$attr->ownerElement->hasAttribute("data-rebind")) {
 				array_push($attributesToRemove, $attrName);

--- a/src/HTMLAttributeCollection.php
+++ b/src/HTMLAttributeCollection.php
@@ -7,7 +7,7 @@ use Gt\Dom\XPathResult;
 class HTMLAttributeCollection {
 	public function find(Element $context):XPathResult {
 		return $context->ownerDocument->evaluate(
-			"descendant-or-self::*[@*[starts-with(name(), 'data-bind')]]",
+			"descendant-or-self::*[@*[starts-with(name(), 'data-bind')] or (@data-element and @data-element != '')]",
 			$context
 		);
 	}

--- a/src/ListElement.php
+++ b/src/ListElement.php
@@ -10,7 +10,7 @@ class ListElement {
 	const ATTRIBUTE_LIST_PARENT = "data-list-parent";
 
 	private string $listItemParentPath;
-	private null|Node|Element $listItemNextSibling;
+	private null|Element $listItemNextSibling;
 	private int $insertCount;
 
 	public function __construct(

--- a/src/TableBinder.php
+++ b/src/TableBinder.php
@@ -187,7 +187,7 @@ class TableBinder {
 		}
 	}
 
-	/** @param array<int, array<int,string>> | array<int, array<string, string>> | array<string, array<int, string>> | array<int, array<int, string> | array<string, string> $array */
+	/** @param array<int, array<int,string>> | array<int, array<string, string>> | array<string, array<int, string>> | array<int, array<int, string>> | array<string, string> $array */
 	public function detectTableDataStructureType(array $array):TableDataStructureType {
 		if(empty($array)) {
 			return TableDataStructureType::NORMALISED;

--- a/src/TableBinder.php
+++ b/src/TableBinder.php
@@ -187,7 +187,7 @@ class TableBinder {
 		}
 	}
 
-	/** @param array<int,array<int,string>>|array<int,array<string,string>>|array<string,array<int,string>>|array<int, array<int,string>|array<string,string>> $array */
+	/** @param array<int, array<int,string>> | array<int, array<string, string>> | array<string, array<int, string>> | array<int, array<int, string> | array<string, string> $array */
 	public function detectTableDataStructureType(array $array):TableDataStructureType {
 		if(empty($array)) {
 			return TableDataStructureType::NORMALISED;

--- a/test/phpunit/DocumentBinderTest.php
+++ b/test/phpunit/DocumentBinderTest.php
@@ -1245,7 +1245,29 @@ class DocumentBinderTest extends TestCase {
 		$sut->setDependencies(...$this->documentBinderDependencies($document));
 		$sut->bindKeyValue("error", "Example error!");
 		$sut->cleanupDocument();
-		self::assertStringContainsStringIgnoringCase("error", (string)$document);
+		$errorDiv = $document->querySelector("form>div");
+		self::assertNotNull($errorDiv);
+		self::assertSame("Example error!", $errorDiv->textContent);
+	}
+
+	public function test_bindElementWithBindValue():void {
+		$document = new HTMLDocument(HTMLPageContent::HTML_REMOVE_UNBOUND_BIND_VALUE);
+		$sut = new DocumentBinder($document);
+		$sut->setDependencies(...$this->documentBinderDependencies($document));
+		$sut->bindKeyValue("error", true);
+		$sut->cleanupDocument();
+		$errorDiv = $document->querySelector("form>div");
+		self::assertNotNull($errorDiv);
+		self::assertSame("There has been an error!", $errorDiv->textContent);
+	}
+
+	public function test_bindElementIsRemovedWhenNotBound():void {
+		$document = new HTMLDocument(HTMLPageContent::HTML_REMOVE_UNBOUND_BIND_VALUE);
+		$sut = new DocumentBinder($document);
+		$sut->setDependencies(...$this->documentBinderDependencies($document));
+		$sut->cleanupDocument();
+		$errorDiv = $document->querySelector("form>div");
+		self::assertNull($errorDiv);
 	}
 
 	public function test_bindData_withList_dataBindList():void {

--- a/test/phpunit/DocumentBinderTest.php
+++ b/test/phpunit/DocumentBinderTest.php
@@ -1261,6 +1261,28 @@ class DocumentBinderTest extends TestCase {
 		self::assertSame("There has been an error!", $errorDiv->textContent);
 	}
 
+	public function test_bindElementRemovesMultiple():void {
+		$document = new HTMLDocument(HTMLPageContent::HTML_ADMIN_PANEL);
+		$sut = new DocumentBinder($document);
+		$sut->setDependencies(...$this->documentBinderDependencies($document));
+		$sut->bindKeyValue("isAdmin", false);
+		$sut->cleanupDocument();
+
+		$panelDiv = $document->querySelector("div.panel");
+		self::assertCount(2, $panelDiv->children);
+	}
+
+	public function test_bindElementRemovesMultiple_doesNotRemoveWithTrue():void {
+		$document = new HTMLDocument(HTMLPageContent::HTML_ADMIN_PANEL);
+		$sut = new DocumentBinder($document);
+		$sut->setDependencies(...$this->documentBinderDependencies($document));
+		$sut->bindKeyValue("isAdmin", true);
+		$sut->cleanupDocument();
+
+		$panelDiv = $document->querySelector("div.panel");
+		self::assertCount(4, $panelDiv->children);
+	}
+
 	public function test_bindElementIsRemovedWhenNotBound():void {
 		$document = new HTMLDocument(HTMLPageContent::HTML_REMOVE_UNBOUND_BIND_VALUE);
 		$sut = new DocumentBinder($document);

--- a/test/phpunit/TestHelper/HTMLPageContent.php
+++ b/test/phpunit/TestHelper/HTMLPageContent.php
@@ -1095,6 +1095,25 @@ HTML;
 </form>
 HTML;
 
+	const HTML_REMOVE_UNBOUND_BIND_VALUE = <<<HTML
+<!doctype html>
+<h1>Log in to the system</h1>
+<form method="post">
+	<div data-element="error">There has been an error!</div>
+	
+	<label>
+		<span>Your email address:</span>
+		<input name="email" type="email" required />
+	</label>
+	<label>
+		<span>Your password:</span>
+		<input name="password" type="password" required />
+	</label>
+	
+	<button name="do" value="login">Log in!</button>
+</form>
+HTML;
+
 	const HTML_DATA_BIND_LIST = <<<HTML
 <!doctype html>
 <h1 data-bind:text="name">Data-bind:list example</h1>

--- a/test/phpunit/TestHelper/HTMLPageContent.php
+++ b/test/phpunit/TestHelper/HTMLPageContent.php
@@ -82,6 +82,16 @@ HTML;
 </div>
 HTML;
 
+	const HTML_ADMIN_PANEL = <<<HTML
+<div class="panel">
+	<p>You are logged in as <span data-bind:text="username">username</span></p>
+	<p data-element="isAdmin">You are an administrator</p>
+	<button name="do" value="save">Save record</button>
+	<button data-element="isAdmin" name="do" value="delete">Delete record</button>
+</div>
+HTML;
+
+
 	const HTML_DIFFERENT_BIND_PROPERTIES = <<<HTML
 <!doctype html>
 <img id="img1" class="main" src="/default.png" alt="Not bound" 


### PR DESCRIPTION
Previously, the `data-element` attribute could be added to any element, and that element would be removed if it did not have any other bind operation performed on it.

For example, on `<p data-element data-bind:text="message"></p>`, if there was no bind to the message key, such as `bindKeyValue("message", "Hello, World!");`, the element was removed.

This new functionality means that you can add a value to the `data-element` attribute, and it can now be bound like any `data-bind` attribute. For example:

```html
<p data-element="error">There was an error</p>
```

```php
function go(Binder $binder):void {
  $binder->bindKeyValue("errorMessage", true);
}
```

